### PR TITLE
Fix removing branches that are written like paths eg. this one

### DIFF
--- a/bin/remove-merged-git-branches
+++ b/bin/remove-merged-git-branches
@@ -22,8 +22,8 @@ print_repo_path () {
 }
 
 print_branch_ref () {
-    remote=`dirname $1`
-    name=`basename $1`
+    remote=`echo $1 | rev | xargs basename | rev`
+    name=`echo $1 | rev | xargs dirname | rev`
     if [[ "$remote" == "." ]]; then
         echo -e " - \033[0;33m$name\033[0m"
     else
@@ -41,8 +41,8 @@ remove_local_branches () {
 
 remove_remote_branches () {
     for branch in $@; do
-        remote=`dirname $branch`
-        name=`basename $branch`
+        remote=`echo $branch | rev | xargs basename | rev`
+        name=`echo $branch | rev | xargs dirname | rev`
 
         echo -e "  $\033[0;35m git push $remote :$name\033[0m"
         git push $remote :$name


### PR DESCRIPTION
When deleting branches like this `origin/ne/fix-remove-path-written-branches` it wanted to delete `fix-remove-path-written-branches` instead of `ne/fix-remove-path-written-branches`.